### PR TITLE
Adds a Yelp pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: v0.4.2
+    hooks:
+      -   id: autopep8-wrapper
+          args: ['-i']
+      -   id: check-yaml
+      -   id: end-of-file-fixer
+      -   id: trailing-whitespace
+      -   id: check-case-conflict
+      -   id: check-merge-conflict

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-e .
+
+pre-commit
+wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 PyYAML==3.11
 sleekxmpp==1.3.1
-wheel==0.24.0


### PR DESCRIPTION
Not sure if this is something you'd be interested in using or not, but it's something I often use. In case you're not familiar with it, the Python style guideline is defined in [PEP8][pep8]. I use a tool called [pre-commit][precommit] (terribly named and impossible to Google for) to manage my Git pre-commit hooks. One of the ones I always set for Python code is to run the PEP8 checker over the scrpit (and modify the code to make it PEP 8 compliant automatically).

I didn't actually format the code in this commit, since that would be a large merge-conflict inducing change, but in case you were interested I figured I'd throw the config I often use up.

To test it:

    pip install pre-commit
    pre-commit install
    # Make changes and commit some Python files, you'll see the hooks run and it will cancel your commit if one fails and make changes for you which you can then `git add` if you like them.

[pep8]: https://www.python.org/dev/peps/pep-0008/
[precommit]: http://pre-commit.com/