### PR TITLE
Make HTTP address configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# https://github.com/github/gitignor
+# https://github.com/github/gitignore
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/config.yml
+++ b/config.yml
@@ -6,6 +6,7 @@ whitelist:
   - siacs.eu
   - gultsch.de
 max_file_size: 20971520 #20MiB
+http_address: 127.0.0.1
 http_port: 8080
 get_url : http://upload.siacs.eu:8080
 put_url : http://upload.siacs.eu:8080

--- a/server.py
+++ b/server.py
@@ -181,7 +181,7 @@ if __name__ == "__main__":
     logging.basicConfig(level=LOGLEVEL,
                             format='%(asctime)-24s %(levelname)-8s %(message)s',
                             filename=args.logfile)
-    server = ThreadedHTTPServer(('0.0.0.0', config['http_port']), HttpHandler)
+    server = ThreadedHTTPServer((config['http_address'], config['http_port']), HttpHandler)
     if 'keyfile' in config and 'certfile' in config:
         server.socket = ssl.wrap_socket(server.socket, keyfile=config['keyfile'], certfile=config['certfile'])
     xmpp = MissingComponent(config['jid'],config['secret'])


### PR DESCRIPTION
Make the HTTP address configurable to make putting this behind reverse proxies and the like easier (and listen on loopback only by default for security minded defaults; if you're going to expose this directly, you should probably have to manually think about it).