### PR TITLE
Add a cronjob example to remove old files

### DIFF
--- a/contrib/crontab.example
+++ b/contrib/crontab.example
@@ -1,0 +1,5 @@
+# Every day at 03:00 remove all files older than 30 days. See the man find note
+# on -atime for rounding error information. If you'd rather only remove files
+# that haven't been accessed for 30 days (and you don't have your drive mounted
+# with the noatime option), use -atime instead.
+0 3 * * * * find /var/www/blobstorage -ctime +30 -type f -exec rm -f \{\} \; >/dev/null 2>&1


### PR DESCRIPTION
Adds an example cronjob to the `contrib` tree which removes files that were created over 30 days ago (with instructions for changing it to files that haven't been accessed for 30 days, though this may have issues if you've got an SSD and have `noatime` turned on).

Should work under crontab for Linux or FreeBSD, and be easily adaptable to other cron daemons.