### PR TITLE
Add expiry and user quotas

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,36 @@ config file.
 For the configuration of the XMPP server side have a look into the contrib
 directory or check the server documentation.
 
+#### Expiry and user quotas
+
+Expiry and user quotas are controlled by four config options:
+
+```expire_interval``` determines how often (in seconds) files should be
+deleted. As every expiry run needs to check all uploaded files of all
+users this should not be set too small.
+
+Files older than ```expire_maxage``` (in seconds) will be deleted by an
+expiry run. Set this to ```0``` to disable deletions based on file age.
+
+After an expiry run at most ```user_quota_soft``` space (in bytes) will be
+occupied per user. The oldest files will be deleted first until the occupied
+space is less than ```user_quota_soft```. Set this to ```0``` to disable
+file deletions based on a users occupied space.
+
+```user_quota_hard``` sets a hard limit how much space (in bytes) a user
+may occupy. If an upload would make his files exceed this size it will be
+rejected. This setting is not dependend on ```expire_interval```. Set
+this to ```0``` to disable upload rejection based on occupied space.
+
+```expire_maxage``` and ```user_quota_soft``` depend on ```expire_interval```.
+
+```user_quota_hard``` is honoured even without expiry runs. But some kind
+of expiry is recommended otherwise a user will not be able to upload
+anymore files once his hard quota is reached.
+
+The difference between ```user_quota_hard``` and ```user_quota_soft```
+determines how much a user may upload per ```expire_interval```.
+
 ### Run
 
 Running the component is as easy as invoking ```python server.py```

--- a/config.yml
+++ b/config.yml
@@ -9,3 +9,9 @@ http_address: 127.0.0.1 #use 0.0.0.0 if you don't want to use a proxy
 http_port: 8080
 get_url : http://upload.yoursite.tld:8080
 put_url : http://upload.yoursite.tld:8080
+#keyfile: /etc/ssl/private/your.key
+#certfile: /etc/ssl/certs/your.crt
+expire_interval: 82800  #time in secs between expiry runs (82800 secs = 23 hours). set to '0' to disable
+expire_maxage: 2592000  #files older than this (in secs) get deleted by expiry runs (2592000 = 30 days)
+user_quota_hard: 104857600   #100MiB. set to '0' to disable rejection on uploads over hard quota
+user_quota_soft: 78643200    #75MiB. set to '0' to disable deletion of old uploads over soft quota an expiry runs


### PR DESCRIPTION
Expiry is controlled by 'expire_interval' and 'expire_maxage' in the config file.

'expire_interval' sets how often old files should be expired (in
    seconds). A '0' (or not setting the entry at all) disables expiry.

'expire_maxage' sets the max age in seconds before files get expired.

'user_quota' sets the maximum space in bytes that a user might use.
    Uploads that will exceed this limit will be refused.
    A '0' (or not setting the entry at all) disables user quotas.

Please note that the line "from threading import Thread" that was removed in pull request #22 because it was not necessary is needed for this PR. 

Expiry also deletes empty directories (as opposed to a simple cron job as in PR #20) to keeps things tidy.