### PR TITLE
fix missing imports

### DIFF
--- a/server.py
+++ b/server.py
@@ -17,6 +17,7 @@ import yaml
 from sleekxmpp.componentxmpp import ComponentXMPP
 from threading import Event
 from threading import Lock
+from threading import Thread
 
 try:
     # Python 3


### PR DESCRIPTION
fixes:

 throws 2015-07-28 20:53:09,440  DEBUG    Expire run finished in 0.030223s
Traceback (most recent call last):
  File "server.py", line 287, in <module>
    t = Thread(target=expire, kwargs={'kill_event': kill_event})
NameError: name 'Thread' is not defined