### PR TITLE
Fixed placement of inclusion of overrides file

### DIFF
--- a/contrib/httpuploadcomponent
+++ b/contrib/httpuploadcomponent
@@ -22,10 +22,10 @@ PIDFILE=/var/run/${NAME}.pid
 USER=prosody
 export LOGNAME=$USER
 
-test -x $DAEMON || exit 0
-
 # Allow user to override default values listed above
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+test -x $DAEMON || exit 0
 
 set -e
 


### PR DESCRIPTION
In the last commit I mistakenly placed the inclusion of the "overrides" file _after_ the $DAEMON variable test instead of before it as I meant to do.