### PR TITLE
Allow bare jids (users) in whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Configuration happens in `config.yml` and is pretty straight forward.
 ```component_jid```, ```component_secret``` and ```component_port``` have to match the corresponding entries in your XMPP
 server config (Refer to the documentation of your server). 
 
-```whitelist``` should contain a list of domains whos JIDs are allowed to
+```whitelist``` should contain a list of domains and/or users whos JIDs are allowed to
 upload files. Remove the entry if you want to allow everyone (not really
 recommended).
 

--- a/config.yml
+++ b/config.yml
@@ -7,6 +7,7 @@ storage_path : ./
 whitelist:
   - yourdomain.tld
   - someotherdomain.tld
+  - dude@domain.tld
 max_file_size: 20971520 #20MiB
 
 http_address: 127.0.0.1 #use 0.0.0.0 if you don't want to use a proxy

--- a/server.py
+++ b/server.py
@@ -145,7 +145,7 @@ class MissingComponent(ComponentXMPP):
             self._sendError(iq,'modify','bad-request','please specify filename and size')
         elif maxfilesize < int(request['size']):
             self._sendError(iq,'modify','not-acceptable','file too large. max file size is '+str(maxfilesize))
-        elif 'whitelist' not in config or iq['from'].domain in config['whitelist']:
+        elif 'whitelist' not in config or iq['from'].domain in config['whitelist'] or iq['from'].bare in config['whitelist']:
             sender = iq['from'].bare
             sender_hash = hashlib.sha1(sender.encode()).hexdigest()
             if config['user_quota_hard'] and quotas.setdefault(sender_hash, 0) + int(request['size']) > config['user_quota_hard']:


### PR DESCRIPTION
Allow more fine-grained control via the whitelist feature.

This might be nice to have especially should you merge https://github.com/siacs/Conversations/pull/1314. This way it is possible to open your upload component to a closed circle of people without allowing everybody in.