### PR TITLE
complete identity information for service discovery

### DIFF
--- a/plugins/upload.py
+++ b/plugins/upload.py
@@ -10,6 +10,7 @@ class upload(base_plugin):
         self.description = "upload files via http"
         self.xep = "0999"
         self.xmpp['xep_0030'].add_feature("eu:siacs:conversations:http:upload")
+        self.xmpp['xep_0030'].add_identity(category='store', itype='file', name='HTTP File Upload')
         self.xmpp.register_handler(
             Callback('Upload request',
                 MatchXPath('{%s}iq/{eu:siacs:conversations:http:upload}request' % self.xmpp.default_ns),


### PR DESCRIPTION
Gabble fails to discover the service without a name. 
As it's also part of the proposed XEP, I included some identity data.