### PR TITLE
Adds example apache proxy configuration

### DIFF
--- a/contrib/apache_proxy_example.conf
+++ b/contrib/apache_proxy_example.conf
@@ -1,0 +1,78 @@
+# Location /etc/apache2/sites-enabled
+# requires: rewrite
+<VirtualHost *:80>
+	ServerName upload.yoursite.tld
+	ServerAdmin webmaster@yoursite.tld
+
+	<IfModule mod_rewrite.c>
+		RewriteEngine On
+		RewriteCond %{HTTPS} off
+		RewriteRule ^/(.*) https://upload.yoursite.tld/$1
+	</IfModule>
+	Redirect  / https://upload.yoursite.tld/
+
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>
+
+<IfModule mod_ssl.c>
+	<VirtualHost *:443>
+		ServerName upload.yoursite.tld
+		ServerAdmin webmaster@yoursite.tld
+
+		# The `storage_path` from your component config
+		DocumentRoot /var/www/blobstorage
+		<Directory /var/www/blobstorage>
+			AllowOverride None
+			Options -Indexes -ExecCGI
+			SetHandler none
+			SetHandler default-handler
+
+			Options -ExecCGI
+			php_flag engine off
+			RemoveHandler .cgi .php .php3 .php4 .php5 .phtml .pl .py .pyc .pyo
+			<Files *>
+				AllowOverride None
+
+				SetHandler none
+				SetHandler default-handler
+
+				Options -ExecCGI
+				php_flag engine off
+				RemoveHandler .cgi .php .php3 .php4 .php5 .phtml .pl .py .pyc .pyo
+			</Files>
+		</Directory>
+
+		# Proxy Settings - `http_port` from the component config
+		RewriteEngine On
+		RewriteCond %{REQUEST_METHOD} !^GET$
+		RewriteRule ^/(.*)$ http://127.0.0.1:8284/$1 [P,L]
+
+		# Logging
+		ErrorLog ${APACHE_LOG_DIR}/error.log
+		CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+		# SSL
+		SSLEngine on
+		SSLProtocol ALL -SSLv2 -SSLv3
+		SSLHonorCipherOrder On
+		SSLCipherSuite HIGH:!aNULL:!MD5
+		SSLCertificateFile yourcert.pem
+		SSLCertificateKeyFile yourprivatekey.key
+		SSLCACertificateFile yourcacert.pem
+		SSLVerifyDepth  10
+		<FilesMatch "\.(cgi|shtml|phtml|php)$">
+			SSLOptions +StdEnvVars
+		</FilesMatch>
+		<Directory /usr/lib/cgi-bin>
+			SSLOptions +StdEnvVars
+		</Directory>
+
+		BrowserMatch "MSIE [2-6]" \
+			nokeepalive ssl-unclean-shutdown \
+			downgrade-1.0 force-response-1.0
+		# MSIE 7 and newer should be able to use keepalive
+		BrowserMatch "MSIE [17-9]" ssl-unclean-shutdown
+
+	</VirtualHost>
+</IfModule>


### PR DESCRIPTION
Has the same purpose as the nginx_site_example:
> Used for TLS termination and serving the files (bypassing the component for GET requests, allowing more advanced caching, or even clustering for the case where a file may be downloaded many times)