### PR TITLE
Fixes python2 FileNotFoundError

### DIFF
--- a/server.py
+++ b/server.py
@@ -32,14 +32,7 @@ try:
     FileNotFoundError
 except NameError:
     # Python 2
-    class FileNotFoundError(IOError):
-        def __init__(self, message=None, *args):
-            super(FileNotFoundError, self).__init__(args)
-            self.message = message
-            self.errno = errno.ENOENT
-
-        def __str__(self):
-            return self.message or os.strerror(self.errno)
+    FileNotFoundError = IOError
 
 
 LOGLEVEL=logging.DEBUG


### PR DESCRIPTION
**Python 2 only**

Currently the server does not reply at all if a file is requested witch does not exist.

The reason for this behavior is that [`open(…)`](https://github.com/siacs/HttpUploadComponent/blob/02e970659fa793941cf16c93cb6eeb11b28e540e/server.py#L231) will throw a `IOError` exception. This exception can not be caught by [`except FileNotFoundError:`](https://github.com/siacs/HttpUploadComponent/blob/02e970659fa793941cf16c93cb6eeb11b28e540e/server.py#L244) because `FileNotFoundError` is only a subclass (derived) of `IOError`. To actually catch a subclass python would have to downcast the thrown object, which is impossible (Because the orginal type of the thrown object isn't `FileNotFoundError`). 

Actually I have no proof that reason above is correct, but at least that's the reason why something like this doesn't work in c++.

**Additional note**
After the change this also catches a few more errors, e.g. file read errors, but sending a 404 in that case too isn't the worst. 