### PR TITLE
answer OPTIONS requests to allow web clients to upload files

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -22,3 +22,4 @@ expire_interval: 82800  #time in secs between expiry runs (82800 secs = 23 hours
 expire_maxage: 2592000  #files older than this (in secs) get deleted by expiry runs (2592000 = 30 days)
 user_quota_hard: 104857600   #100MiB. set to '0' to disable rejection on uploads over hard quota
 user_quota_soft: 78643200    #75MiB. set to '0' to disable deletion of old uploads over soft quota an expiry runs
+allow_web_clients: true #answer OPTIONS requests to allow web clients to upload files 

--- a/server.py
+++ b/server.py
@@ -248,6 +248,15 @@ class HttpHandler(BaseHTTPRequestHandler):
     def do_HEAD(self):
         self.do_GET(body=False)
 
+    def do_OPTIONS(self):
+        if 'allow_web_clients' in config and config['allow_web_clients']:
+            self.send_response(200, 'OK')
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Access-Control-Allow-Methods", "GET,PUT")
+            self.end_headers()
+        else:
+            self.send_response(501, 'NO OPTIONS')
+            self.end_headers()
 
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
     """Handle requests in a separate thread."""


### PR DESCRIPTION
Web clients like Movim need some CORS headers to be allowed to upload files.