### PR TITLE
SSL for both security and compatibility; max_body_size for location.

### DIFF
--- a/contrib/nginx_site_example
+++ b/contrib/nginx_site_example
@@ -6,13 +6,18 @@ server {
     ssl_certificate      yourcert.pem
     ssl_certificate_key  yourprivatekey.key;
 
-    # Add other protocols here if you need them. TLSv1 and TLSv1.1 might be required if you use old clients.
-    ssl_protocols  TLSv1.2;
-    # Not very backwards compatible, but very secure. Choose something that suites you.
-    ssl_ciphers EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH;
-    # The default cipher:
-    # ssl_ciphers HIGH:!aNULL:!MD5;
-    ssl_prefer_server_ciphers   on;
+    ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    ssl_session_tickets off; # Requires nginx >= 1.5.9
+    ssl_stapling on; # Requires nginx >= 1.3.7
+    ssl_stapling_verify on; # Requires nginx => 1.3.7
+    resolver $DNS-IP-1 $DNS-IP-2 valid=300s;
+    resolver_timeout 5s;
 
     root /var/www/blobstorage; # The `storage_path` from your component config
 

--- a/contrib/nginx_site_example
+++ b/contrib/nginx_site_example
@@ -27,6 +27,7 @@ server {
         limit_except GET {
             proxy_pass       http://[::]:8284; # `http_port` from the component config
         }
+        client_max_body_size 20M; # The `max_file_size` from your component config
         proxy_set_header Host        $host;
         charset          utf-8;
         add_header       Strict-Transport-Security "max-age=31536000; includeSubdomains";


### PR DESCRIPTION
I've set ssl settings accroding to [cipherli.st](cipherli.st) for best compatibility and security, and also added 
    client_max_body_size 20M;
that should fix problems with smaller default nginx setting

I've just realized I should've made two separate pull requests...