### PR TITLE
nginx_site_example: Specify client_max_body_size

### DIFF
--- a/contrib/nginx_site_example
+++ b/contrib/nginx_site_example
@@ -16,6 +16,8 @@ server {
 
     root /var/www/blobstorage; # The `storage_path` from your component config
 
+    client_max_body_size 20m; # Shouldn't be smaller than `max_file_size` in your component config
+
     # If you set `get_url` and `put_url` to include a custom path, be sure to change location to match
     # or split this out into multiple location blocks.
     location / {


### PR DESCRIPTION
Set the maximum allowed size of the HTTP request body to 20 MB in the Nginx example configuration. By default, Nginx rejects the PUT request if the body is larger than 1 MB.