### PR TITLE
Use pyvenv instead of virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: test build
 $(VENV): $(VENV)/bin/activate
 
 $(VENV)/bin/activate: requirements.txt
-	test -d $(VENV) || virtualenv -p /usr/bin/python3 $(VENV)
+	test -d $(VENV) || pyvenv $(VENV)
 	$(ACTIVATE); pip install -r requirements.txt
 	touch $(BIN)/activate
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ PyYAML==3.11
 six==1.9.0
 sleekxmpp==1.3.1
 tox==2.1.1
-virtualenv==13.1.2
 wheel==0.24.0


### PR DESCRIPTION
Now that we're Python 3 only, use Python 3's builtin pyvenv command (this rarely matters since the virtualenv command can already do Python 3 venvs, but pyvenv is better anyways and will already be installed if they've got Python 3 installed).