### PR TITLE
Allow configuring of XMPP host + some cleanup

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -2,24 +2,24 @@ component_jid: upload.yourdomain.tld
 component_secret: yoursecret
 component_port: 5347
 
-storage_path : ./
+storage_path: ./
 
 whitelist:
   - yourdomain.tld
   - someotherdomain.tld
   - dude@domain.tld
-max_file_size: 20971520 #20MiB
+max_file_size: 20971520  # 20MiB
 
-http_address: 127.0.0.1 #use 0.0.0.0 if you don't want to use a proxy
+http_address: 127.0.0.1  # use 0.0.0.0 if you don't want to use a proxy
 http_port: 8080
-#http_keyfile: /etc/ssl/private/your.key
-#http_certfile: /etc/ssl/certs/your.crt
+# http_keyfile: /etc/ssl/private/your.key
+# http_certfile: /etc/ssl/certs/your.crt
 
-get_url : http://upload.yoursite.tld:8080
-put_url : http://upload.yoursite.tld:8080
+get_url: http://upload.yoursite.tld:8080
+put_url: http://upload.yoursite.tld:8080
 
-expire_interval: 82800  #time in secs between expiry runs (82800 secs = 23 hours). set to '0' to disable
-expire_maxage: 2592000  #files older than this (in secs) get deleted by expiry runs (2592000 = 30 days)
-user_quota_hard: 104857600   #100MiB. set to '0' to disable rejection on uploads over hard quota
-user_quota_soft: 78643200    #75MiB. set to '0' to disable deletion of old uploads over soft quota an expiry runs
-allow_web_clients: true #answer OPTIONS requests to allow web clients to upload files 
+expire_interval: 82800  # time in secs between expiry runs (82800 secs = 23 hours). set to '0' to disable
+expire_maxage: 2592000  # files older than this (in secs) get deleted by expiry runs (2592000 = 30 days)
+user_quota_hard: 104857600  # 100MiB. set to '0' to disable rejection on uploads over hard quota
+user_quota_soft: 78643200  # 75MiB. set to '0' to disable deletion of old uploads over soft quota an expiry runs
+allow_web_clients: true  # answer OPTIONS requests to allow web clients to upload files

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,5 +1,6 @@
 component_jid: upload.yourdomain.tld
 component_secret: yoursecret
+component_host: localhost
 component_port: 5347
 
 storage_path: ./

--- a/httpupload/server.py
+++ b/httpupload/server.py
@@ -111,8 +111,8 @@ def expire(quotaonly=False, kill_event=None):
 
 
 class MissingComponent(ComponentXMPP):
-    def __init__(self, jid, secret, port):
-        ComponentXMPP.__init__(self, jid, secret, "localhost", port)
+    def __init__(self, jid, secret, host, port):
+        ComponentXMPP.__init__(self, jid, secret, host, port)
         self.register_plugin('xep_0030')
         self.register_plugin('upload',module='plugins.upload')
         self.add_event_handler('request_upload_slot',self.request_upload_slot)
@@ -309,8 +309,9 @@ if __name__ == "__main__":
         server.socket = ssl.wrap_socket(server.socket, keyfile=config['http_keyfile'], certfile=config['http_certfile'])
     jid = config['component_jid']
     secret = config['component_secret']
-    port = int(config.get('component_port',5347))
-    xmpp = MissingComponent(jid,secret,port)
+    host = config.get('component_host', 'localhost')
+    port = int(config.get('component_port', 5347))
+    xmpp = MissingComponent(jid, secret, host, port)
     if xmpp.connect():
         xmpp.process()
         print("connected")

--- a/tests/unit/server_test.py
+++ b/tests/unit/server_test.py
@@ -12,16 +12,6 @@ def fakeos():
         )
         return fakeos
 
-def test_file_not_found_error_exists():
-    """
-    Ensure that FileNotFound error exists (as a fallback for Python 2.7).
-    """
-
-    try:  # pragma: no cover
-        FileNotFoundError
-    except NameError:  # pragma: no cover
-        server.FileNotFoundError
-
 def test_path_normalization():
     """
     Ensure that paths are properly normalized to prevent accessing '../'
@@ -49,7 +39,7 @@ def test_path_normalization():
     }
 
     for key in cases.keys():
-        assert cases[key] == server.normalize_path(key)
+        assert cases[key] == server.normalize_path(key, 0)
 
 def test_expire_no_kill_event(fakeos):
     """


### PR DESCRIPTION
Adds a new config key 'component_host' to refer to the XMPP server to which the HttpUploadComponent should connect. This is useful for Docker etc., where the component not necessarily is in the same container as the XMPP server.